### PR TITLE
Fix - Add missing slash in secret link

### DIFF
--- a/client/src/components/NewSecret.vue
+++ b/client/src/components/NewSecret.vue
@@ -177,7 +177,7 @@ export default {
         )
       )
 
-      const link = `${window.location.origin}#${data}`
+      const link = `${window.location.origin}/#${data}`
 
       this.store.setLink(link)
     }


### PR DESCRIPTION
Without the slash, the link was not properly picked up when pasting in Discord.